### PR TITLE
fix(sysupgrade): use curl instead ping - icmp not always available

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -47,7 +47,7 @@ quick_reboot() {
 
 
 
-if ! ping -q -c 3 -w 3 github.com >/dev/null 2>&1; then
+if [ "$(curl -o /dev/null -s -w '%{http_code}\n' http://github.com)" != "301" ]; then
   echo -e "\n\e[1;31mThere is no access to the github.com, please check the Internet connection...\e[0m\n"
   exit 1
 else


### PR DESCRIPTION
ICMP to github.com is not reliable. If no connection available, curl will send "000" status.